### PR TITLE
feat: use init for managing wpa_supplicant

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -17,6 +17,7 @@ wifi_off() {
 
     if pgrep wpa_supplicant; then
         echo "Stopping wpa_supplicant..."
+        /etc/init.d/wpa_supplicant stop || true
         killall -9 wpa_supplicant || true
     fi
 
@@ -77,7 +78,8 @@ wifi_on() {
     rfkill unblock wifi || true
 
     echo "Starting wpa_supplicant..."
-    wpa_supplicant -B -D nl80211 -iwlan0 -c /etc/wifi/wpa_supplicant.conf -O /etc/wifi/sockets || true
+    /etc/init.d/wpa_supplicant stop || true
+    /etc/init.d/wpa_supplicant start || true
     ( (udhcpc -i wlan0 &) &)
 
     DELAY=30


### PR DESCRIPTION
Instead of manually stopping/starting wpa_supplicant, use init. This ensures the system handles wifi correctly according to it's own process management.