### PR TITLE
refactor: prefer wifi.txt at root of the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Browse to `Tools > Toggle Wifi` and press `A` to toggle wifi on/off.
 
 ### Customizing Wifi Credentials
 
-In the `/Tools/tg3040/Toggle Wifi.pak` folder, there will be a `wifi.txt` file. This file should store network credentials for accessing your wifi networks.
+In the root of your SD card, place a `wifi.txt` file. This file should store network credentials for accessing your wifi networks.
+
+> [!NOTE]
+> In previous versions of the pak, this file could also be located at `/Tools/tg3040/Toggle Wifi.pak/wifi.txt`. The old path is still supported - though deprecated - and users should migrate to the new path. New versions of the pak will transparently migrate the `wifi.txt` to the root of the SD card.
 
 Format:
 

--- a/launch.sh
+++ b/launch.sh
@@ -46,7 +46,14 @@ wifi_on() {
     cp "$progdir/res/wpa_supplicant.conf.tmpl" "$progdir/res/wpa_supplicant.conf"
     echo "Generating wpa_supplicant.conf..."
 
-    echo "" >>"$progdir/wifi.txt"
+    if [ ! -f "$SDCARD_PATH/wifi.txt" ] && [ -f "$progdir/wifi.txt" ]; then
+        cp "$progdir/wifi.txt" "$SDCARD_PATH/wifi.txt"
+    fi
+
+    touch "$SDCARD_PATH/wifi.txt"
+    sed -i '/^$/d' "$SDCARD_PATH/wifi.txt"
+
+    echo "" >>"$SDCARD_PATH/wifi.txt"
     while read -r line; do
         line="$(echo "$line" | xargs)"
         if [ -z "$line" ]; then
@@ -70,7 +77,7 @@ wifi_on() {
             echo "    psk=\"$psk\""
             echo "}"
         } >>"$progdir/res/wpa_supplicant.conf"
-    done <"$progdir/wifi.txt"
+    done <"$SDCARD_PATH/wifi.txt"
 
     cp "$progdir/res/wpa_supplicant.conf" /etc/wifi/wpa_supplicant.conf
 


### PR DESCRIPTION
Placing the wifi.txt at the root of the device is more user-friendly - you don't need to hunt around for where to place the file, and it allows using the same sd card on other devices. We still support the old, pak-specific file, but migrate it for users so they don't have to.