### PR TITLE
fix: use the same wifi detection as minui

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -101,7 +101,7 @@ wifi_on() {
 
 main() {
     echo "Toggling wifi..."
-    if pgrep wpa_supplicant; then
+    if grep -q "up" /sys/class/net/wlan0/operstate; then
         show.elf "$RES_PATH/stopping.png" 2
         echo "Stopping wifi..."
         wifi_off


### PR DESCRIPTION
MinUI does not check for wpa_supplicant, but instead checks the status at /sys/class/net/wlan0/operstate. Switching to what it does is better for knowing whether to toggle or not, as there are cases where wpa_supplicant is running but is otherwise down.